### PR TITLE
Changed location of HyDE demo

### DIFF
--- a/WP3_Advanced_RAG_HyDE_Example.ipynb
+++ b/WP3_Advanced_RAG_HyDE_Example.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# WP3 Advanced RAG\n",
+    "\n",
+    "## HyDE Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**HyDE** (Hypothetical Document Embeddings) is an advanced RAG technique that specifically improves the retrieval of relevant documents. \n",
+    "\n",
+    "In basic RAG, semantic search compares a query against the documents in the database.  \n",
+    "But sometimes the documents being searched through are in a very different form to the queries asked.\n",
+    "\n",
+    "HyDE attempts to improve this by doing a document to document semantic comparison.  \n",
+    "An LLM uses the query to produce a hypothetical document in the same form that they are found in the database.  \n",
+    "This hypothetical document is then used as the starting point for the semantic search."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "import random\n",
+    "\n",
+    "\n",
+    "import toml\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "import src.models as models\n",
+    "\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "config = toml.load(\"config.toml\")\n",
+    "load_dotenv(\".secrets\")\n",
+    "os.environ[\"ANTHROPIC_API_KEY\"] = os.getenv(\"anthropic_key\")\n",
+    "\n",
+    "if config['DEV_MODE']:\n",
+    "    config['PERSIST_DIRECTORY'] += \"/dev\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in rag_demo.ipynb, we first initialise the RAG pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rag_pipeline = models.RagPipeline(config['EMBEDDING_MODEL'], config['PERSIST_DIRECTORY'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also need to fill in the database if it is empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add documents if there are non - if in DEV mode, don't add any more (if it's not empty)\n",
+    "if len(rag_pipeline.vectorstore.get()['documents']) == 0 or (not config['DEV_MODE']):\n",
+    "    rag_pipeline.load_documents()  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will also load in a random question from cogstack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#load processed questions and answers\n",
+    "cogstack_qa = pd.read_csv('src/model_eval/cogstack_qa_data_process.csv')\n",
+    "\n",
+    "#select a random sample question\n",
+    "sample_qa = cogstack_qa.sample(n = 1, random_state = 999)\n",
+    "\n",
+    "question = sample_qa['question'].values[0]\n",
+    "print(question)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using HyDE\n",
+    "\n",
+    "We will now use HyDE to answer a RAG question. For an example using only basic RAG, please look at rag_demo.ipynb.\n",
+    "\n",
+    "We request a response from the LLM with both `rag` and `hyde` turned on.\n",
+    "\n",
+    "When generating a hypothetical document, the following prompt is used:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Generate a hypothetical NHS conditions page based on the following question.\\\n",
+    "Focus on providing a comprehensive overview, including key details about the condition's symptoms, underlying causes,\\\n",
+    "and recommended treatment modalities. Keep in mind the target audience of general readers seeking reliable health information.\\\n",
+    "The conditions page should be under 1000 characters.\n",
+    "    \n",
+    "QUESTION: \"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The response to this prompt is then used to retrieve relevant documents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_hyde_on = rag_pipeline.answer_question(question, rag=True, hyde=True)\n",
+    "\n",
+    "print(result_hyde_on)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluating HyDE\n",
+    "\n",
+    "We can compare RAG results with and wihout HyDE. The following code iterates through 50 question answer pairs, 5 times, and checks whether the correct refereces have been used in the response. \n",
+    "\n",
+    "The folling code does take a while to run, so a summary of previous experiments is shown below:\n",
+    "\n",
+    "| Random Sample|     HyDE Scores |Mean HyDE Score| No HyDE Scores      | Mean No HyDE Score|\n",
+    "|--------------|-----------------|---------------|---------------------|-------------------|\n",
+    "| 999          | 28 27 27 26 26  |     26.8      | 27 27 26 27 27      |       26.8        |\n",
+    "| 1000         | 38 30 27 31 26  |     30.4      | 29 28 26 28 28      |       27.8        | \n",
+    "| 1001         | 30 32 31 31 32  |     31.2      | 28 32 28 28 27      |       28.6        |\n",
+    "\n",
+    "Testing on 3 random samples of 50 questions, we found that HyDE was marginally better at retrieving the correct references.\n",
+    "\n",
+    "Score refers to the number of answers containing the correct reference.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_scores = {}\n",
+    "\n",
+    "# Non-deterministic nature of LLM's means we want to test HyDE multiple times on the same test set.\n",
+    "for sample in range(5):\n",
+    "\n",
+    "    # Sample 50 questions\n",
+    "    sample_size = 50\n",
+    "    sample_questions = cogstack_qa.sample(n = sample_size, random_state = 1001)\n",
+    "\n",
+    "    score_hyde_on  = 0\n",
+    "    score_hyde_off = 0\n",
+    "\n",
+    "    for index,row in enumerate(sample_questions.itertuples()):\n",
+    "        \n",
+    "        question = row.question\n",
+    "        \n",
+    "        result_hyde_off = rag_pipeline.answer_question(question, rag=True, hyde=False)\n",
+    "        result_hyde_on  = rag_pipeline.answer_question(question, rag=True, hyde=True)\n",
+    "\n",
+    "        for result, hyde_on in zip([result_hyde_off,result_hyde_on],[False,True]):\n",
+    "        \n",
+    "            # Check if the LLM quoted one of the references used in the cogstack response\n",
+    "            try: \n",
+    "                idx  = result.split().index('SOURCES:')\n",
+    "                # Occasionaslly outputs do not include any sources. Need to andle these errors.\n",
+    "            \n",
+    "                sources = []\n",
+    "\n",
+    "                for i in result.split()[idx + 1:]:\n",
+    "                    j = i.replace('(', '')\n",
+    "                    j = j.replace(')', '')\n",
+    "                    j = j.replace('.txt', '')\n",
+    "                    j = j.replace(',', '')\n",
+    "                    sources.append(j)\n",
+    "\n",
+    "                for i in sources:\n",
+    "                    if i in row.reference:\n",
+    "                        if hyde_on:\n",
+    "                            score_hyde_on += 1\n",
+    "                        else:\n",
+    "                            score_hyde_off += 1\n",
+    "                \n",
+    "            except ValueError as e:\n",
+    "                print(e)\n",
+    "                print(result)\n",
+    "\n",
+    "    source_scores[f\"sample_{sample}_hyde_on\"] = score_hyde_on\n",
+    "    source_scores[f\"sample_{sample}_hyde_off\"] = score_hyde_off\n",
+    "\n",
+    "    print(f\"\\nSample {sample}\")\n",
+    "    print(f\"Correct references with HyDE: {score_hyde_on} / {sample_size}\")\n",
+    "    print(f\"Correct references without HyDE: {score_hyde_off} / {sample_size}\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have removed the HyDE example from RAG demo, and created a new file that is specifically for a HyDE demo. This is to make it more obvious to find in the future. Most of the code is directly copied across from the old HyDE example.

In both files, I cleared all outputs to prevent any accidental data leak, and to make future pull requests less likely to have conflicts.